### PR TITLE
Framework E (17.104.x): Java 21 / WildFly 32 / Jakarta EE 10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [21.0.0-SNAPSHOT] - 2026-04-14
+### Changed
+- Bumped version to `21.0.0-SNAPSHOT` for Java 21 / WildFly 34 migration
+- Updated parent `cp-maven-parent-pom` to `21.0.0-SNAPSHOT`
+- Java compiler source/target/release: `17` → `21`
+- `enforcer.java.version.range`: `[17,)` → `[21,)`
+- `java.se.version`: `17` → `21`
+- `java.ee.version`: `8` → `10`
+- `javaee-api.version`: `8.0.1` → `10.0.0` (Jakarta EE 10)
+- `plugins.jacoco.version`: `0.8.8` → `0.8.12`
+- `jakarta.xml.bind-api.version`: `2.3.2` → `4.0.0`
+
 ## [17.10.13] - 2025-09-09
 ### Changed
 - Remove distribution management from pom.xml and prepare for public repo migration

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# cpp-platform-maven-parent-pom
+
+`uk.gov.moj.cpp.common:parent-pom`
+
+The root Maven parent POM for the Criminal Practice Platform (CPP). It mirrors the role of `cp-maven-parent-pom` in the framework tier but serves the platform and bounded-context tier: `cpp-platform-libraries`, `cpp-platform-core-domain`, `cpp-platform-maven-service-parent-pom`, and all `cpp-context-*` services inherit from this project (directly or transitively).
+
+## Position in the hierarchy
+
+```
+maven-super-pom  (external)
+└── cpp-platform-maven-parent-pom  ← this project
+    ├── cpp-platform-maven-common-bom
+    └── cpp-platform-libraries
+        └── cpp-platform-maven-service-parent-pom
+            └── [all cpp-context-* bounded-context services]
+```
+
+`cp-maven-parent-pom` is a sibling — both inherit from `maven-super-pom` independently.
+
+## Maven coordinates
+
+| Property | Value |
+|---|---|
+| `groupId` | `uk.gov.moj.cpp.common` |
+| `artifactId` | `parent-pom` |
+| Parent | `uk.gov.justice:maven-super-pom` |
+
+## What this POM provides
+
+**Java / Jakarta EE target**
+- Java 21 (`<compiler.source/target/release>21`)
+- Jakarta EE 10
+- Enforcer requires Java ≥ 21 and Maven ≥ 3.3.9
+
+**Build conventions** (same as the framework tier)
+- Compiler warnings and lint enabled; max 100 errors / 100 warnings
+- `src/raml/json` copied to `target/generated-test-resources/json`
+- `src/raml/json/schema` copied to `target/generated-resources/json/schema`
+- JaCoCo coverage agent wired to all test phases
+- `ci.buildNode` populated from environment on Windows and Unix
+- `web.context.root` defaults to `/${project.artifactId}` (overridable per WAR)
+
+**Plugin management** — same plugin stack as `cp-maven-parent-pom`: compiler, surefire/failsafe, enforcer, jacoco, jar, war, resources, assembly, source, javadoc, buildnumber, versions, pitest, sonar, wildfly, liquibase, exec.
+
+**Profiles** — `raml-jar`, `liquibase-jar`, `jandex-index`, `release`, `pitest`, `windows`/`unix`.
+
+**Enforcer rules** — in addition to the standard Java/Maven version checks, this POM includes `enforce-moj-latest-interfaces` which verifies that dependencies on MOJ interface JARs (such as `progression-query-api`) reference the latest released version. This rule has `<skip>false</skip>` hardcoded and cannot be bypassed with `-Denforcer.skip=true`.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j21
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:parent-pom"

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>21.0.0-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Parent POM</name>
@@ -169,7 +169,7 @@
         <ci.hook.fixup-versions.skip>true</ci.hook.fixup-versions.skip>
 
         <!-- Updated by CI hooks -->
-        <cpp.parent-pom.version>21.0.0-SNAPSHOT</cpp.parent-pom.version>
+        <cpp.parent-pom.version>21.0.0-M1-SNAPSHOT</cpp.parent-pom.version>
     </properties>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>17.0.0</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>17.10.15-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Parent POM</name>
@@ -36,17 +36,17 @@
 
         <!-- Enforcer settings - ranges need to be in the format defined at http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html -->
         <enforcer.maven.version.range>[${maven.minimum.version},)</enforcer.maven.version.range>
-        <enforcer.java.version.range>[17,)</enforcer.java.version.range>
+        <enforcer.java.version.range>[21,)</enforcer.java.version.range>
 
         <!-- Java API versions targeted -->
-        <java.se.version>17</java.se.version>
-        <java.ee.version>8</java.ee.version>
-        <javaee-api.version>8.0.1</javaee-api.version>
+        <java.se.version>21</java.se.version>
+        <java.ee.version>10</java.ee.version>
+        <javaee-api.version>10.0.0</javaee-api.version>
 
         <!-- Compilation properties -->
-        <compiler.source>17</compiler.source>
-        <compiler.target>17</compiler.target>
-        <compiler.release>17</compiler.release>
+        <compiler.source>21</compiler.source>
+        <compiler.target>21</compiler.target>
+        <compiler.release>21</compiler.release>
         <compiler.debug>true</compiler.debug>
         <compiler.debuglevel>lines,vars,source</compiler.debuglevel>
         <compiler.showdeprecation>true</compiler.showdeprecation>
@@ -89,9 +89,13 @@
         <picocli.version>4.6.3</picocli.version>
 
         <!-- JaxB dependencies -->
+        <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
-        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
         <activation.version>1.1</activation.version>
+
+        <!-- Azure legacy SDK -->
+        <azure-storage-version>8.4.0</azure-storage-version>
 
         <!-- Camunda and associated dependencies -->
         <cpp.camunda.version>7.17.0</cpp.camunda.version>
@@ -127,7 +131,7 @@
         <plugins.maven.sonar.version>3.11.0.3922</plugins.maven.sonar.version>
 
 
-        <plugins.jacoco.version>0.8.8</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.12</plugins.jacoco.version>
         <plugins.raml.utils.version>1.2.5</plugins.raml.utils.version>
         <plugins.jaxb2.version>0.15.2</plugins.jaxb2.version>
         <plugins.jaxws.version>2.5</plugins.jaxws.version>
@@ -165,7 +169,7 @@
         <ci.hook.fixup-versions.skip>true</ci.hook.fixup-versions.skip>
 
         <!-- Updated by CI hooks -->
-        <cpp.parent-pom.version>17.10.15-SNAPSHOT</cpp.parent-pom.version>
+        <cpp.parent-pom.version>21.0.0-SNAPSHOT</cpp.parent-pom.version>
     </properties>
 
     <!--


### PR DESCRIPTION
## Summary
Upgrades `cpp-platform-maven-parent-pom` to Java 21 / WildFly 32 / Jakarta EE 10 as part of the Framework E (17.104.x) release line backport.

## Related
Framework E docs and status: https://github.com/hmcts/java-21-wildfly-32-updgrade-pilot-cpp-framework/blob/main/status/17.104.x-status.md