### PR TITLE
Java 25 / WildFly 40 spike — platform parent POM version bump to 25.104.0-M1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Parent POM</name>
@@ -169,7 +169,7 @@
         <ci.hook.fixup-versions.skip>true</ci.hook.fixup-versions.skip>
 
         <!-- Updated by CI hooks -->
-        <cpp.parent-pom.version>21.0.0-M1-SNAPSHOT</cpp.parent-pom.version>
+        <cpp.parent-pom.version>25.104.0-M1-SNAPSHOT</cpp.parent-pom.version>
     </properties>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>25.104.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cpp-platform-maven-parent-pom

Spike to prove viability of upgrading the CPP platform directly from Java 17 to **Java 25 / WildFly 40 / Jakarta EE 11** (25.104.0-M1-SNAPSHOT).

**Spike gate: cpp-context-users-groups integration tests — 96/96 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Platform parent POM version bump to 25.104.0-M1-SNAPSHOT

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
https://github.com/hmcts/cpp-framework-java-upgrade-pilot/blob/main/status/25.104.x-status.md