### PR TITLE
Upgrade maven-shade-plugin to 3.6.0 and JaCoCo to 0.8.14 for Java 25 (25.104.0-M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M2] - 2026-06-10
+### Changed
+- Bumped `plugins.jacoco.version` from `0.8.12` to `0.8.14` — JaCoCo 0.8.12 cannot instrument Java 25 class files (major version 69); 0.8.14 adds ASM 9.7 support for Java 25
+
 ## [25.104.0-M1] - 2026-06-09
 ### Changed
 - Updated parent `maven-super-pom` to `25.104.0-M1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 
+## [25.104.0-M1] - 2026-06-09
+### Changed
+- Updated parent `maven-super-pom` to `25.104.0-M1`
+- Java compiler source/target/release: `21` → `25`
+- `enforcer.java.version.range`: `[21,)` → `[25,)`
+- `java.se.version`: `21` → `25`
+- `java.ee.version`: `10` → `11`
+- `javaee-api.version`: `10.0.0` → `11.0.0` (Jakarta EE 11)
+
+## [21.0.0-SNAPSHOT] - 2026-04-14
+### Changed
+- Bumped version to `21.0.0-SNAPSHOT` for Java 21 / WildFly 34 migration
+- Updated parent `cp-maven-parent-pom` to `21.0.0-SNAPSHOT`
+- Java compiler source/target/release: `17` → `21`
+- `enforcer.java.version.range`: `[17,)` → `[21,)`
+- `java.se.version`: `17` → `21`
+- `java.ee.version`: `8` → `10`
+- `javaee-api.version`: `8.0.1` → `10.0.0` (Jakarta EE 10)
+- `plugins.jacoco.version`: `0.8.8` → `0.8.12`
+- `jakarta.xml.bind-api.version`: `2.3.2` → `4.0.0`
+
 ## [17.10.13] - 2025-09-09
 ### Changed
 - Remove distribution management from pom.xml and prepare for public repo migration

--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# cpp-platform-maven-parent-pom
+
+`uk.gov.moj.cpp.common:parent-pom`
+
+The root Maven parent POM for the Criminal Practice Platform (CPP). It mirrors the role of `cp-maven-parent-pom` in the framework tier but serves the platform and bounded-context tier: `cpp-platform-libraries`, `cpp-platform-core-domain`, `cpp-platform-maven-service-parent-pom`, and all `cpp-context-*` services inherit from this project (directly or transitively).
+
+## Position in the hierarchy
+
+```
+maven-super-pom  (external)
+└── cpp-platform-maven-parent-pom  ← this project
+    ├── cpp-platform-maven-common-bom
+    └── cpp-platform-libraries
+        └── cpp-platform-maven-service-parent-pom
+            └── [all cpp-context-* bounded-context services]
+```
+
+`cp-maven-parent-pom` is a sibling — both inherit from `maven-super-pom` independently.
+
+## Maven coordinates
+
+| Property | Value |
+|---|---|
+| `groupId` | `uk.gov.moj.cpp.common` |
+| `artifactId` | `parent-pom` |
+| Parent | `uk.gov.justice:maven-super-pom` |
+
+## What this POM provides
+
+**Java / Jakarta EE target**
+- Java 21 (`<compiler.source/target/release>21`)
+- Jakarta EE 10
+- Enforcer requires Java ≥ 21 and Maven ≥ 3.3.9
+
+**Build conventions** (same as the framework tier)
+- Compiler warnings and lint enabled; max 100 errors / 100 warnings
+- `src/raml/json` copied to `target/generated-test-resources/json`
+- `src/raml/json/schema` copied to `target/generated-resources/json/schema`
+- JaCoCo coverage agent wired to all test phases
+- `ci.buildNode` populated from environment on Windows and Unix
+- `web.context.root` defaults to `/${project.artifactId}` (overridable per WAR)
+
+**Plugin management** — same plugin stack as `cp-maven-parent-pom`: compiler, surefire/failsafe, enforcer, jacoco, jar, war, resources, assembly, source, javadoc, buildnumber, versions, pitest, sonar, wildfly, liquibase, exec.
+
+**Profiles** — `raml-jar`, `liquibase-jar`, `jandex-index`, `release`, `pitest`, `windows`/`unix`.
+
+**Enforcer rules** — in addition to the standard Java/Maven version checks, this POM includes `enforce-moj-latest-interfaces` which verifies that dependencies on MOJ interface JARs (such as `progression-query-api`) reference the latest released version. This rule has `<skip>false</skip>` hardcoded and cannot be bypassed with `-Denforcer.skip=true`.

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -22,7 +22,7 @@ resources:
 pool:
   name: "MDV-ADO-AGENT-AKS-01"
   demands:
-    - identifier -equals centos8-j17
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   sonarqubeProject: "uk.gov.moj.cpp.common:parent-pom"

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <plugins.maven.sonar.version>3.11.0.3922</plugins.maven.sonar.version>
 
 
-        <plugins.jacoco.version>0.8.12</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.14</plugins.jacoco.version>
         <plugins.raml.utils.version>1.2.5</plugins.raml.utils.version>
         <plugins.jaxb2.version>0.15.2</plugins.jaxb2.version>
         <plugins.jaxws.version>2.5</plugins.jaxws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-super-pom</artifactId>
-        <version>17.0.0</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <groupId>uk.gov.moj.cpp.common</groupId>
     <artifactId>parent-pom</artifactId>
-    <version>17.10.15-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CPP Parent POM</name>
@@ -36,17 +36,17 @@
 
         <!-- Enforcer settings - ranges need to be in the format defined at http://maven.apache.org/enforcer/enforcer-rules/versionRanges.html -->
         <enforcer.maven.version.range>[${maven.minimum.version},)</enforcer.maven.version.range>
-        <enforcer.java.version.range>[17,)</enforcer.java.version.range>
+        <enforcer.java.version.range>[25,)</enforcer.java.version.range>
 
         <!-- Java API versions targeted -->
-        <java.se.version>17</java.se.version>
-        <java.ee.version>8</java.ee.version>
-        <javaee-api.version>8.0.1</javaee-api.version>
+        <java.se.version>25</java.se.version>
+        <java.ee.version>11</java.ee.version>
+        <javaee-api.version>11.0.0</javaee-api.version>
 
         <!-- Compilation properties -->
-        <compiler.source>17</compiler.source>
-        <compiler.target>17</compiler.target>
-        <compiler.release>17</compiler.release>
+        <compiler.source>25</compiler.source>
+        <compiler.target>25</compiler.target>
+        <compiler.release>25</compiler.release>
         <compiler.debug>true</compiler.debug>
         <compiler.debuglevel>lines,vars,source</compiler.debuglevel>
         <compiler.showdeprecation>true</compiler.showdeprecation>
@@ -89,9 +89,13 @@
         <picocli.version>4.6.3</picocli.version>
 
         <!-- JaxB dependencies -->
+        <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-runtime.version>2.3.1</jaxb-runtime.version>
-        <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
+        <jakarta.xml.bind-api.version>4.0.0</jakarta.xml.bind-api.version>
         <activation.version>1.1</activation.version>
+
+        <!-- Azure legacy SDK -->
+        <azure-storage-version>8.4.0</azure-storage-version>
 
         <!-- Camunda and associated dependencies -->
         <cpp.camunda.version>7.17.0</cpp.camunda.version>
@@ -127,7 +131,7 @@
         <plugins.maven.sonar.version>3.11.0.3922</plugins.maven.sonar.version>
 
 
-        <plugins.jacoco.version>0.8.8</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.12</plugins.jacoco.version>
         <plugins.raml.utils.version>1.2.5</plugins.raml.utils.version>
         <plugins.jaxb2.version>0.15.2</plugins.jaxb2.version>
         <plugins.jaxws.version>2.5</plugins.jaxws.version>
@@ -165,7 +169,7 @@
         <ci.hook.fixup-versions.skip>true</ci.hook.fixup-versions.skip>
 
         <!-- Updated by CI hooks -->
-        <cpp.parent-pom.version>17.10.15-SNAPSHOT</cpp.parent-pom.version>
+        <cpp.parent-pom.version>25.104.0-M1-SNAPSHOT</cpp.parent-pom.version>
     </properties>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <plugins.maven.war.version>3.2.2</plugins.maven.war.version>
         <plugins.taglist.version>2.4</plugins.taglist.version>
         <plugins.versions.version>2.5</plugins.versions.version>
-        <plugins.maven.shade.version>3.1.1</plugins.maven.shade.version>
+        <plugins.maven.shade.version>3.6.0</plugins.maven.shade.version>
 
         <plugins.buildnumber.version>1.4</plugins.buildnumber.version>
         <plugins.buildhelper.version>3.0.0</plugins.buildhelper.version>


### PR DESCRIPTION
## Summary

- Upgrades `maven-shade-plugin` from `3.1.1` to `3.6.0` — fixes the double-lifecycle bug with Maven 3.9.16 where shade calls `project.setFile(dependency-reduced-pom.xml)`, causing Maven to re-execute the lifecycle with `basedir=target/`, the second `clean` deletes `target/`, and the subsequent `jar` execution fails. The `3.1.1` bug required a `<createDependencyReducedPom>false</createDependencyReducedPom>` workaround in 4 liquibase poms across `cpp-context-users-groups` and `cpp-context-prosecution-casefile`; once this PR is released those workarounds can be removed.
- Upgrades JaCoCo from `0.8.12` to `0.8.14` — required for Java 25 class file support (major version 69). Earlier versions fail to instrument Java 25 bytecode.

## Test plan

- [ ] Local build passes with `mmse` against the `java-25-wildfly-40-upgrade-spike` chain
- [ ] CI passes on merge
- [ ] Once released as M2, remove the 4 `<createDependencyReducedPom>false</createDependencyReducedPom>` workarounds from the liquibase poms in `cpp-context-users-groups` and `cpp-context-prosecution-casefile`

## Related

- `cpp-context-users-groups` PR #204 (CI passing, awaiting review) — contains the shade workaround that this PR makes redundant
- `cpp-context-prosecution-casefile` PR #92 (CI passing, awaiting review) — same