### PR TITLE
Java 25 plugin fixes: jacoco 0.8.14, shade 3.6.0, drop dead buildnumber param (M2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Bumped `plugins.jacoco.version` `0.8.12` → `0.8.14` for Java 25 class-file support (JaCoCo 0.8.12 cannot read class files produced by JDK 25).
+- Bumped `plugins.maven.shade.version` `3.1.1` → `3.6.0`. shade 3.1.1 calls `project.setFile()` after writing `dependency-reduced-pom.xml`, causing Maven 3.9 to re-run the lifecycle with `basedir=target/`; the second `clean` deletes the file before the second `jar` execution reads it (`dependency-reduced-pom.xml isn't a file`) — hitting every context using the Liquibase fat-jar profile. 3.6.0 no longer calls `project.setFile()` in the package phase, so the context-level `createDependencyReducedPom=false` workarounds can be removed once this is published.
+
+### Fixed
+- Removed the dead `<useLatestCommittedRevision>` entry from the `buildnumber-maven-plugin` config (unknown parameter — the real name is `useLastCommittedRevision`, and the value was the default `false`), eliminating the `[WARNING] Parameter 'useLatestCommittedRevision' is unknown for plugin 'buildnumber-maven-plugin'` build warning.
 
 ## [25.104.0-M1] - 2026-06-09
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <plugins.maven.war.version>3.2.2</plugins.maven.war.version>
         <plugins.taglist.version>2.4</plugins.taglist.version>
         <plugins.versions.version>2.5</plugins.versions.version>
-        <plugins.maven.shade.version>3.1.1</plugins.maven.shade.version>
+        <plugins.maven.shade.version>3.6.0</plugins.maven.shade.version>
 
         <plugins.buildnumber.version>1.4</plugins.buildnumber.version>
         <plugins.buildhelper.version>3.0.0</plugins.buildhelper.version>
@@ -131,7 +131,7 @@
         <plugins.maven.sonar.version>3.11.0.3922</plugins.maven.sonar.version>
 
 
-        <plugins.jacoco.version>0.8.12</plugins.jacoco.version>
+        <plugins.jacoco.version>0.8.14</plugins.jacoco.version>
         <plugins.raml.utils.version>1.2.5</plugins.raml.utils.version>
         <plugins.jaxb2.version>0.15.2</plugins.jaxb2.version>
         <plugins.jaxws.version>2.5</plugins.jaxws.version>
@@ -477,7 +477,6 @@
                         <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                         <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
                         <shortRevisionLength>7</shortRevisionLength>
-                        <useLatestCommittedRevision>false</useLatestCommittedRevision>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
## Summary

Prepares **cpp-platform-maven-parent-pom** for its next release (**M2**) — the top of the platform Maven hierarchy, and first in the platform release chain. Three Java-25 plugin fixes that had been stranded on the divergent `java-25-jacoco-fix` branch (never merged to the release line), re-applied cleanly onto `release/25.104.x`:

### Changed
- **`plugins.jacoco.version` `0.8.12` → `0.8.14`** — JaCoCo 0.8.12 cannot read class files produced by JDK 25.
- **`plugins.maven.shade.version` `3.1.1` → `3.6.0`** — shade 3.1.1 calls `project.setFile()` after writing `dependency-reduced-pom.xml`, causing Maven 3.9 to re-run the lifecycle with `basedir=target/`; the second `clean` deletes the file before the second `jar` execution reads it (`dependency-reduced-pom.xml isn't a file`). This hit every context using the Liquibase fat-jar profile. 3.6.0 no longer calls `project.setFile()` in the package phase — so the context-level `createDependencyReducedPom=false` workarounds can be removed once this is published.

### Fixed
- Removed the dead `<useLatestCommittedRevision>` param from the `buildnumber-maven-plugin` config (the real name is `useLastCommittedRevision`, and the value matched the default) — eliminates the per-build unknown-parameter warning.

## Context
The Java 25/WF40 base upgrade already reached `release/25.104.x` (via #13, released as **M1**); the branch is on **M2-SNAPSHOT**. These three fixes are the M2 delta. As the top of the platform hierarchy, once released the downstream platform repos (common-bom, service-parent-pom, core-domain) will bump their parent to M2 to pick up the shade/jacoco fixes.

Target: **`release/25.104.x`**.
